### PR TITLE
Change the APIs and tests to provide more direction on refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ software. Here are some of the criteria we'll be evaluating you against:
 4. How good are you at recognizing and communicating tradeoffs?
 
 Feel free to google stuff, check reference docs, or ask for help along the way.
-Also, don't feel any pressure to finish the exercise. We'll get to where-ever
+Also, don't feel any pressure to finish the exercise. We'll get to whereever
 we get to, and that's perfectly fine.
 
 The project doesn't ship with any additional dependencies, feel free to add any

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ software. Here are some of the criteria we'll be evaluating you against:
 4. How good are you at recognizing and communicating tradeoffs?
 
 Feel free to google stuff, check reference docs, or ask for help along the way.
-Also, don't feel any pressure to finish the exercise. We'll get to whereever
+Also, don't feel any pressure to finish the exercise. We'll get to wherever
 we get to, and that's perfectly fine.
 
 The project doesn't ship with any additional dependencies, feel free to add any

--- a/lib/enbala/battery.ex
+++ b/lib/enbala/battery.ex
@@ -14,19 +14,15 @@ defmodule Enbala.Battery do
   """
   defstruct [:id, :current_power, rated_power: 10]
 
-  def all() do
-    []
+  def new(_params) do
+    {:error, :not_implemented}
   end
 
   def get(_id) do
     nil
   end
 
-  def create(_params) do
-    {:error, :not_implemented}
-  end
-
-  def set_current_power(_id, _power_value) do
+  def update_current_power(_id, _power_value) do
     {:error, :not_implemented}
   end
 end

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -9,6 +9,10 @@ defmodule Enbala.Vpp do
   of power to the grid.
   """
 
+  def add_asset(battery) do
+    :ok
+  end
+
   def current_power do
     0
   end

--- a/test/battery_test.exs
+++ b/test/battery_test.exs
@@ -10,39 +10,34 @@ defmodule Enbala.BatteryTest do
   end
 
   @tag :skip
-  test ".create takes a map of parameters, builds a struct and persists" do
+  test ".new takes a map of parameters and builds a struct" do
     battery_params = %{id: "battery_1"}
 
-    assert {:ok, %Battery{}} = Battery.create(battery_params)
+    assert {:ok, %Battery{}} = Battery.new(battery_params)
   end
 
   @tag :skip
-  test ".get with a previously created id retrieves the struct" do
-    id = "battery_1"
-    Battery.create(%{id: id})
+  test ".get returns a previously created battery struct" do
+    {:ok, created} = Battery.new(%{id: "b1", current_power: 50, rated_power: 100})
 
-    assert %Battery{id: ^id} = Battery.get(id)
+    assert Battery.get("b1") == created
+  end
+
+  test ".new does basic validations" do
+    # TODO: What should we do here?
+    assert {:error, _} = Battery.new(%{id: nil})
+
+    # TODO: Should we enforce current_power <= rated_power?
+    assert {:error, _} = Battery.new(%{id: "b1", current_power: 999, rated_power: 10})
+
+    # TODO: Other validations?
   end
 
   @tag :skip
-  test ".get with an id that hasn't been created" do
-    assert nil == Battery.get("unknown_id")
-  end
+  test ".update_current_power/2" do
+    {:ok, battery} = Battery.new(%{id: "b1", current_power: 100, rated_power: 1_000})
+    updated_battery = Battery.set_current_power("b1", 50)
 
-  @tag :skip
-  test ".all returns battery structs that have been created" do
-    id = "battery_1"
-    Battery.create(%{id: id})
-
-    assert [%Battery{id: ^id}] = Battery.all()
-  end
-
-  @tag :skip
-  test ".set_current_power/2" do
-    id = "battery_1"
-    Battery.create(%{id: id})
-    Battery.set_current_power(id, 5)
-
-    assert %Battery{current_power: 5} = Battery.get(id)
+    assert updated_battery.current_power == 50
   end
 end

--- a/test/vpp_test.exs
+++ b/test/vpp_test.exs
@@ -7,56 +7,69 @@ defmodule Enbala.VppTest do
   @tag :skip
   test ".current_power returns the sum of all asset's current_power" do
     first_battery = "battery_1"
-    Battery.create(%{id: first_battery, current_power: 8})
+    Battery.new(%{id: first_battery, current_power: 8})
     second_battery = "battery_2"
-    Battery.create(%{id: second_battery, current_power: 3})
+    Battery.new(%{id: second_battery, current_power: 3})
 
-    assert Vpp.current_power == 11
+    Vpp.add_asset(first_battery)
+    Vpp.add_asset(second_battery)
+
+    assert Vpp.current_power() == 11
   end
 
   @tag :skip
   test ".export updates assets setpoint" do
     id = "battery_1"
-    Battery.create(%{id: id})
+    Battery.new(%{id: id})
+    Vpp.add_asset(id)
 
-    assert Vpp.current_power == 0
+    assert Vpp.current_power() == 0
 
     Vpp.export(5)
 
     assert %Battery{current_power: 5} = Battery.get(id)
-    assert Vpp.current_power == 5
+    assert Vpp.current_power() == 5
   end
 
   @tag :skip
   test ".export updates assets setpoint respecting rated_power" do
     id = "battery_1"
-    Battery.create(%{id: id})
+    Battery.new(%{id: id})
+    Vpp.add_asset(id)
+
     Vpp.export(20)
+
     assert %Battery{current_power: 10} = Battery.get(id)
-    assert Vpp.current_power == 10
+    assert Vpp.current_power() == 10
   end
 
   @tag :skip
   test ".export with multiple batteries disperses load across batteries" do
     first_battery = "battery_1"
-    Battery.create(%{id: first_battery})
+    Battery.new(%{id: first_battery})
     second_battery = "battery_2"
-    Battery.create(%{id: second_battery})
+    Battery.new(%{id: second_battery})
+
+    Vpp.add_asset(first_battery)
+    Vpp.add_asset(second_battery)
 
     Vpp.export(10)
 
     assert %Battery{current_power: 5} = Battery.get(first_battery)
     assert %Battery{current_power: 5} = Battery.get(second_battery)
 
-    assert Vpp.current_power == 10
+    assert Vpp.current_power() == 10
   end
 
   @tag :skip
   test ".export delivers additional power to grid" do
     first_battery = "battery_1"
-    Battery.create(%{id: first_battery, current_power: 8})
+    Battery.new(%{id: first_battery, current_power: 8})
     second_battery = "battery_2"
-    Battery.create(%{id: second_battery, current_power: 3})
+    Battery.new(%{id: second_battery, current_power: 3})
+
+    Vpp.add_asset(first_battery)
+    Vpp.add_asset(second_battery)
 
     Vpp.export(2)
 


### PR DESCRIPTION
Here are my proposed changes.

I think the plan for interviewing would be:

1. Start with `Battery`. Have a conversation about the API and how the candidate might handle state here. Make it clear the API is entirely flexible.
2. Go through some code-test-refactor cycles on `battery_test.exs` until we get through at least the tests that are there; maybe the candidate wants to add new tests too, maybe not.
3. Move over to `Vpp` and start thinking about how _it_ should manage statefulness.
4. Do some code-test-refactor cycles on `vpp_test.exs` until we feel like we've seen enough to know how the candidate works.