### PR TITLE
Remove statefulness from Battery

### DIFF
--- a/lib/enbala/battery.ex
+++ b/lib/enbala/battery.ex
@@ -18,11 +18,7 @@ defmodule Enbala.Battery do
     {:error, :not_implemented}
   end
 
-  def get(_id) do
-    nil
-  end
-
-  def update_current_power(_id, _power_value) do
+  def update_current_power(_battery_struct, _power_value) do
     {:error, :not_implemented}
   end
 end

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -17,6 +17,10 @@ defmodule Enbala.Vpp do
     0
   end
 
+  def batteries do
+    []
+  end
+
   def export(_power) do
     :ok
   end

--- a/test/battery_test.exs
+++ b/test/battery_test.exs
@@ -17,12 +17,6 @@ defmodule Enbala.BatteryTest do
   end
 
   @tag :skip
-  test ".get returns a previously created battery struct" do
-    {:ok, created} = Battery.new(%{id: "b1", current_power: 50, rated_power: 100})
-
-    assert Battery.get("b1") == created
-  end
-
   test ".new does basic validations" do
     # TODO: What should we do here?
     assert {:error, _} = Battery.new(%{id: nil})


### PR DESCRIPTION
This removes `Battery.get/1`, so that the `Battery` tests suggest a pure, function-operating-on-a-struct approach, while `Vpp` suggests statefulness.