### PR TITLE
Clarifications and Fixes

### DIFF
--- a/lib/enbala/battery.ex
+++ b/lib/enbala/battery.ex
@@ -1,16 +1,16 @@
 defmodule Enbala.Battery do
   @moduledoc """
   When Enbala is managing the health of the power grid, a battery connected to
-  the grid (via a smart inverter) is a really helpful tool to be able to leverage.
-  They're capable of exporting power to the grid if there isn't enough generation,
-  absorb power if there's too much generation, and even regulate frequency (and
-  that's not all!).
+  the grid (via a smart inverter) is a really helpful tool to be able to
+  leverage. They're capable of exporting power to the grid if there isn't
+  enough generation, absorb power if there's too much generation, and even
+  regulate frequency (and that's not all!).
 
-  Our battery module is a little bit simpler than real-world batteries. We're only
-  interested in keeping track of three things for our batteries. A unique `id`
-  that we can use to send it messages, the amount of power the battery is currently
-  contributing to the grid (current_power), and what the maximum amount of power the
-  battery could contribute to the grid (rated_power).
+  Our battery module is a little bit simpler than real-world batteries. We're
+  only interested in keeping track of three things for our batteries. A unique
+  `id` that we can use to send it messages, the amount of power the battery is
+  currently contributing to the grid (current_power), and what the maximum
+  amount of power the battery could contribute to the grid (rated_power).
   """
   defstruct [:id, :current_power, rated_power: 10]
 

--- a/lib/enbala/battery.ex
+++ b/lib/enbala/battery.ex
@@ -3,14 +3,18 @@ defmodule Enbala.Battery do
   When Enbala is managing the health of the power grid, a battery connected to
   the grid (via a smart inverter) is a really helpful tool to be able to
   leverage. They're capable of exporting power to the grid if there isn't
-  enough generation, absorb power if there's too much generation, and even
-  regulate frequency (and that's not all!).
+  enough generation, absorbing power if there's too much generation, and even
+  regulating frequency (and that's not all!).
 
-  Our battery module is a little bit simpler than real-world batteries. We're
-  only interested in keeping track of three things for our batteries. A unique
-  `id` that we can use to send it messages, the amount of power the battery is
-  currently contributing to the grid (current_power), and what the maximum
-  amount of power the battery could contribute to the grid (rated_power).
+  Our `Battery` module is a little bit simpler than real-world batteries. We're
+  only interested in keeping track of three things for our batteries:
+
+    * `id`: a unique id that we can use to send it messages
+    * `current_power`: the amount of power the battery is currently
+      contributing to the grid
+    * `rated_power`: the maximum amount of power the battery could contribute
+      to the grid
+
   """
   defstruct [:id, :current_power, rated_power: 10]
 

--- a/lib/enbala/battery.ex
+++ b/lib/enbala/battery.ex
@@ -1,19 +1,18 @@
 defmodule Enbala.Battery do
   @moduledoc """
   When Enbala is managing the health of the power grid, a battery connected to
-  the grid (via a smart inverter) is a really helpful tool to be able to
-  leverage. They're capable of exporting power to the grid if there isn't
-  enough generation, absorbing power if there's too much generation, and even
-  regulating frequency (and that's not all!).
+  the grid is a useful tool. Batteries are capable of exporting power to the
+  grid if there isn't enough generation, absorbing power if there's too much
+  generation, and even regulating frequency (and that's not all!).
 
   Our `Battery` module is a little bit simpler than real-world batteries. We're
   only interested in keeping track of three things for our batteries:
 
-    * `id`: a unique id that we can use to send it messages
-    * `current_power`: the amount of power the battery is currently
+    * `id` - a unique id that we can use to send it messages
+    * `current_power` - the amount of power the battery is currently
       contributing to the grid
-    * `rated_power`: the maximum amount of power the battery could contribute
-      to the grid
+    * `rated_power` - the maximum amount of power the battery could
+      contribute to the grid
 
   """
   defstruct [:id, :current_power, rated_power: 10]

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -12,7 +12,7 @@ defmodule Enbala.Vpp do
     * `export`: export an additional amount of power to the grid
   """
 
-  def add_asset(battery) do
+  def add_asset(_battery) do
     :ok
   end
 

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -12,7 +12,7 @@ defmodule Enbala.Vpp do
 
   """
 
-  def add_asset(_battery) do
+  def add_battery(_battery) do
     :ok
   end
 

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -4,10 +4,12 @@ defmodule Enbala.Vpp do
   batteries in our case, that we can use to bring additional stability to the
   grid.
 
-  Our Vpp module is simpler than what would be used in the real-world, it can
-  only do two things. Firstly, it can calculate the total amount of power all
-  of our batteries are contributing to the grid. Secondly, it can be asked to
-  export an additional amount of power to the grid.
+  Our `Vpp` module is simpler than what would be used in the real-world, it can
+  only do two things:
+
+    * `current_power`: calculate the total amount of power all our batteries
+      are contributing to the grid
+    * `export`: export an additional amount of power to the grid
   """
 
   def add_asset(battery) do

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -1,12 +1,13 @@
 defmodule Enbala.Vpp do
   @moduledoc """
-  A Virtual Power Plant or VPP is a collection of controllable assets, batteries in our
-  case, that we can use to bring additional stability to the grid.
+  A Virtual Power Plant or VPP is a collection of controllable assets,
+  batteries in our case, that we can use to bring additional stability to the
+  grid.
 
-  Our Vpp module is simpler than what would be used in the real-world, it can only do
-  two things. Firstly, it can calculate the total amount of power all of our batteries
-  are contributing to the grid. Secondly, it can be asked to export an additional amount
-  of power to the grid.
+  Our Vpp module is simpler than what would be used in the real-world, it can
+  only do two things. Firstly, it can calculate the total amount of power all
+  of our batteries are contributing to the grid. Secondly, it can be asked to
+  export an additional amount of power to the grid.
   """
 
   def add_asset(battery) do

--- a/lib/enbala/vpp.ex
+++ b/lib/enbala/vpp.ex
@@ -1,15 +1,15 @@
 defmodule Enbala.Vpp do
   @moduledoc """
-  A Virtual Power Plant or VPP is a collection of controllable assets,
-  batteries in our case, that we can use to bring additional stability to the
-  grid.
+  A Virtual Power Plant (VPP) is a collection of controllable assets, batteries
+  in our case, that we can use to bring additional stability to the grid.
 
   Our `Vpp` module is simpler than what would be used in the real-world, it can
   only do two things:
 
-    * `current_power`: calculate the total amount of power all our batteries
+    * `current_power` - calculate the total amount of power all our batteries
       are contributing to the grid
-    * `export`: export an additional amount of power to the grid
+    * `export` - export an additional amount of power to the grid
+
   """
 
   def add_asset(_battery) do

--- a/test/battery_test.exs
+++ b/test/battery_test.exs
@@ -30,7 +30,7 @@ defmodule Enbala.BatteryTest do
   @tag :skip
   test ".update_current_power/2" do
     {:ok, battery} = Battery.new(%{id: "b1", current_power: 100, rated_power: 1_000})
-    updated_battery = Battery.set_current_power(battery, 50)
+    updated_battery = Battery.update_current_power(battery, 50)
 
     assert updated_battery.current_power == 50
   end

--- a/test/vpp_test.exs
+++ b/test/vpp_test.exs
@@ -16,7 +16,7 @@ defmodule Enbala.VppTest do
   end
 
   @tag :skip
-  test ".export updates assets setpoint" do
+  test ".export updates asset's setpoint" do
     {:ok, battery} = Battery.new(%{id: "battery_1"})
     Vpp.add_asset(battery)
 
@@ -30,7 +30,7 @@ defmodule Enbala.VppTest do
   end
 
   @tag :skip
-  test ".export updates assets setpoint respecting rated_power" do
+  test ".export updates asset's setpoint respecting rated_power" do
     {:ok, battery} = Battery.new(%{id: "battery_1"})
     Vpp.add_asset(battery)
 

--- a/test/vpp_test.exs
+++ b/test/vpp_test.exs
@@ -9,8 +9,8 @@ defmodule Enbala.VppTest do
     {:ok, first_battery} = Battery.new(%{id: "battery_1", current_power: 8})
     {:ok, second_battery} = Battery.new(%{id: "battery_2", current_power: 3})
 
-    Vpp.add_asset(first_battery)
-    Vpp.add_asset(second_battery)
+    Vpp.add_battery(first_battery)
+    Vpp.add_battery(second_battery)
 
     assert Vpp.current_power() == 11
   end
@@ -18,7 +18,7 @@ defmodule Enbala.VppTest do
   @tag :skip
   test ".export updates asset's setpoint" do
     {:ok, battery} = Battery.new(%{id: "battery_1"})
-    Vpp.add_asset(battery)
+    Vpp.add_battery(battery)
 
     assert Vpp.current_power() == 0
 
@@ -32,7 +32,7 @@ defmodule Enbala.VppTest do
   @tag :skip
   test ".export updates asset's setpoint respecting rated_power" do
     {:ok, battery} = Battery.new(%{id: "battery_1"})
-    Vpp.add_asset(battery)
+    Vpp.add_battery(battery)
 
     Vpp.export(20)
 
@@ -46,8 +46,8 @@ defmodule Enbala.VppTest do
     {:ok, first_battery} = Battery.new(%{id: "battery_1"})
     {:ok, second_battery} = Battery.new(%{id: "battery_2"})
 
-    Vpp.add_asset(first_battery)
-    Vpp.add_asset(second_battery)
+    Vpp.add_battery(first_battery)
+    Vpp.add_battery(second_battery)
 
     Vpp.export(10)
 
@@ -63,8 +63,8 @@ defmodule Enbala.VppTest do
     {:ok, first_battery} = Battery.new(%{id: "battery_1", current_power: 8})
     {:ok, second_battery} = Battery.new(%{id: "battery_2", current_power: 3})
 
-    Vpp.add_asset(first_battery)
-    Vpp.add_asset(second_battery)
+    Vpp.add_battery(first_battery)
+    Vpp.add_battery(second_battery)
 
     Vpp.export(2)
 


### PR DESCRIPTION
These are a handful of small changes intended to cut down on confusion during pairing interviews.

## Changes

- The function `update_current_power` had been renamed (from `set_current_power`) and this PR removes an accidental reference to the old function name.
- Added an underscore to the `battery` argument in `Vpp.add_asset/1` to avoid warning output in test runs.
- Renamed `Vpp.add_asset/1` to `Vpp.add_battery/1` to match the `Vpp.batteries/0` fetch.
- Attempted to rewrite moduledocs for the `Battery` and `Vpp` modules. The thinking is that it's hard to read a paragraph of text during a pairing interview, so I'm hoping the bullet points will make it just _slightly_ easier to scan. I also ran the content through hemingwayapp.com in hopes of clarifying, but I think there's probably more we could do to keep it as simple as possible for interviewees.

## Questions

- [x] _[Update: Fixed by renaming `add_asset` to `add_battery` for consistency.]_ Should we change the `batteries` function name to `assets` or maybe `all_assets`? It's a little odd to have `add_asset` when we're adding and then `batteries` when we're fetching. Or the other option would be to call the add function `add_battery` to keep them consistent.